### PR TITLE
[WIP] Use WaterLily's density_coefficient! for the variable-density L

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 WaterLily = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 
+# TEMPORARY: density_coefficient! lives on this WaterLily branch (stacked on
+# WaterLily PR #291). Remove this [sources] pin once it lands upstream.
+[sources]
+WaterLily = {url = "https://github.com/pankgeorg/WaterLily.jl", rev = "variable-density"}
+
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -1,4 +1,4 @@
-import WaterLily: accelerate!, median, update!, project!, scale_u!, exitBC!,perBC!,residual!,mult, flux_out, vanLeer, L∞, ϕ
+import WaterLily: accelerate!, median, update!, project!, scale_u!, exitBC!,perBC!,residual!,mult, flux_out, vanLeer, L∞, ϕ, density_coefficient!
 import LinearAlgebra: ⋅, rmul!, axpy!
 
 # I need to re-define the flux limiter or else the TVD property cannot conserve
@@ -78,8 +78,9 @@ end
     viscSurfTenρu!(a.f,a.u,c.ρuf,a.σ,c.f⁰,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir)
     u2ρu!(c.n̂,a.u⁰,c.f,c.λρ) # steal n̂ as original momentum
     updateU!(a.u,c.ρu,c.n̂,a.f,δt,c.f⁰,c.λρ,tₘ,a.g,a.uBC,dtCoeff); BC!(a.u,a.uBC,a.exitBC,a.perdir)
-    updateL!(a.μ₀,c.f⁰,c.λρ;perdir=a.perdir); 
-    update!(b)
+    # L = μ₀/ρ_face refreshed once per step from the volume fraction, via
+    # WaterLily's core hook (1/ρ computed on the fly — no stored ρ array).
+    density_coefficient!(b, a.μ₀, let fρ=c.f⁰, λρ=c.λρ; (d,I)->inv(getρ(d,I,fρ,λρ)); end; perdir=a.perdir)
     myproject!(a,b,dtCoeff); BC!(a.u,a.uBC,a.exitBC,a.perdir)
 
     # copyto!(c.f, c.f⁰)
@@ -99,8 +100,7 @@ end
     viscSurfTenρu!(a.f,a.u,c.ρuf,a.σ,c.f,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir) 
     u2ρu!(c.n̂,a.u⁰,c.f,c.λρ) # steal n̂ as original momentum
     updateU!(a.u,c.ρu,c.n̂,a.f,δt,c.f,c.λρ,t₁,a.g,a.uBC); BC!(a.u,a.uBC,a.exitBC,a.perdir)
-    updateL!(a.μ₀,c.f,c.λρ;perdir=a.perdir); 
-    update!(b)
+    density_coefficient!(b, a.μ₀, let fρ=c.f, λρ=c.λρ; (d,I)->inv(getρ(d,I,fρ,λρ)); end; perdir=a.perdir)
     myproject!(a,b); BC!(a.u,a.uBC,a.exitBC,a.perdir)
 
     push!(a.Δt,min(MPCFL(a,c),1.2δt))


### PR DESCRIPTION
> **Draft / companion PR.** Depends on `density_coefficient!` from WaterLily (`pankgeorg/WaterLily.jl@variable-density`, stacked on WaterLily PR #291). The `[sources]` git pin in `Project.toml` is temporary until that lands upstream.

## What

Replaces the hand-rolled `updateL!` + `update!(b)` in `MPFMomStep!` with WaterLily's core `density_coefficient!(b, a.μ₀, invρ)`, which folds `1/ρ_face` into the Poisson coefficient `L = μ₀/ρ_face` and refreshes the solver (diagonal + multigrid restriction). `invρ` is supplied as the existing on-the-fly face closure

```julia
density_coefficient!(b, a.μ₀, let fρ=c.f⁰, λρ=c.λρ; (d,I)->inv(getρ(d,I,fρ,λρ)); end; perdir=a.perdir)
```

so density is still computed from the volume fraction with **no stored ρ array**, exactly as before. Because the primitive folds in the (measured) `μ₀`, it is also correct for moving immersed bodies — the `# TODO: include measure` case.

## Why

It's the same computation `updateL!` does, routed through a shared WaterLily primitive so the coefficient plumbing (`μ₀·(1/ρ) → L → diagonal/level refresh`) lives in one place and serves both this package and algebraic-VoF downstreams. The face-averaging convention stays here (`getρ`); WaterLily only owns the `μ₀·invρ → update!` machinery.

## Performance — no regression

`MPFMomStep!` on `TGVDroplet3D(32)`, SIMD backend, single thread, **identical WaterLily** (so this isolates the `updateL!` → `density_coefficient!` change):

| case | main (`updateL!`) | this PR (`density_coefficient!`) |
|---|---|---|
| inviscid | 59.3 ms / 2.55 KiB | 60.1 ms / 2.83 KiB |
| Re=100   | 64.2 ms / 2.58 KiB | 65.0 ms / 2.86 KiB |
| We=100   | 64.7 ms / 2.58 KiB | 65.5 ms / 2.86 KiB |

Time is at parity (within run-to-run noise). Allocation is ~0.28 KiB/step higher (≈64 B per `density_coefficient!` call, ×2/step). The primitive was tuned to get here — taking `D` from `μ₀`'s type so the `SVector{D}` is concrete, and specializing on the `invρ` type so the on-the-fly closure inlines (this dropped the per-call cost from ~768 B → 64 B). Still ~17× under the 50 KiB `alloctest` budget. `updateL!` is left defined (now unused) for easy comparison.

**Correctness:** results are **bit-identical** to `main` — 3 `MPFMomStep!`s on `TGVDroplet3D(32, Re=100)` give the same `sum(u)`, `sumabs2(u)`, `sum(f)` with and without this change (`density_coefficient!` computes the same `L=μ₀/ρ` over the same face range as `updateL!`). Note: `test/maintests.jl` currently has an unrelated pre-existing failure on Julia 1.12 (`myArgAbsMax` in `util.jl`), independent of this change.
