### PR TITLE
Unify viscosity calculation of inline and cross terms

### DIFF
--- a/src/VOFutil.jl
+++ b/src/VOFutil.jl
@@ -183,8 +183,13 @@ Specify at `IJEQUAL` with `Val{i==j}()`.
 The calculated viscosity is limited with the majority fluid's kinematic viscosity applied to interpolation.
 The dynamic viscosity is then recovered using the minimal density of the cells who are going to use the stress flux.
 """
-@inline @fastmath getμCell(i,j,I,f,λμ,μ,λρ) = μ*linInterpProp(f[I-δ(i,I)],λμ)
-@inline @fastmath function getμEdge(i,j,I,f::AbstractArray{T,D},λμ,μ,λρ) where {T,D}
+@inline @fastmath function getμCell(i,j,I,f,fFace,λμ,μ,λρ)
+    f1,f2 = fFace[I-δ(i,I),i],fFace[I,i]
+    s = f1+f2
+    fmin = λρ < 1 ? min(f1,f2) : max(f1,f2)
+    return μ*min(linInterpProp(s,λμ), ifelse(s>0.5,1,λμ/λρ)*linInterpProp(fmin,λρ))
+end
+@inline @fastmath function getμEdge(i,j,I,f::AbstractArray{T,D},fFace,λμ,μ,λρ) where {T,D}
     f1,f2,f3,f4 = f[I],f[I-δ(i,I)],f[I-δ(i,I)-δ(j,I)],f[I-δ(j,I)]
     s = (f1+f2+f3+f4)/4
     fmin = λρ < 1 ? min(f1+f2,f2+f3,f3+f4,f4+f1)/2 : max(f1+f2,f2+f3,f3+f4,f4+f1)/2
@@ -229,7 +234,7 @@ end
 
 function f2face!(fFace, fCen::AbstractArray{T,D}; perdir=()) where {T,D}
     for d∈1:D
-        @loop fFace[I,d] = ϕ(d,I,fCen) over I∈inside_uWB(size(fCen),d)
+        @loop fFace[I,d] = ϕ(d,I,fCen) over I∈inside(fCen)
     end
     BCv!(fFace;perdir)
 end

--- a/src/VOFutil.jl
+++ b/src/VOFutil.jl
@@ -175,25 +175,18 @@ Linearly interpolate density at either `I` or `I-0.5d`.
 @inline @fastmath getρ(d,I,f,λρ) = linInterpProp(ϕ(d,I,f),λρ)
 
 """
-    getμ(i,j,I,f,λμ,μ,λρ)
+    getμ(i,j,I,fFace,λμ,μ,λρ)
 
 Calculate the viscosity corresponding to the term ∂ⱼuᵢ @ either `I-0.5i-0.5j` or `I-1i`.
 The function return the linear interpolation at cell center (when `i==j`) or cell vertex (when `i≠j`).
-Specify at `IJEQUAL` with `Val{i==j}()`.
 The calculated viscosity is limited with the majority fluid's kinematic viscosity applied to interpolation.
 The dynamic viscosity is then recovered using the minimal density of the cells who are going to use the stress flux.
 """
-@inline @fastmath function getμCell(i,j,I,f,fFace,λμ,μ,λρ)
-    f1,f2 = fFace[I-δ(i,I),i],fFace[I,i]
-    s = f1+f2
-    fmin = λρ < 1 ? min(f1,f2) : max(f1,f2)
-    return μ*min(linInterpProp(s,λμ), ifelse(s>0.5,1,λμ/λρ)*linInterpProp(fmin,λρ))
-end
-@inline @fastmath function getμEdge(i,j,I,f::AbstractArray{T,D},fFace,λμ,μ,λρ) where {T,D}
-    f1,f2,f3,f4 = f[I],f[I-δ(i,I)],f[I-δ(i,I)-δ(j,I)],f[I-δ(j,I)]
+@inline @fastmath function getμ(i,j,I,fFace,λμ,μ,λρ)
+    f1,f2,f3,f4 = fFace[I-δ(j,I),i],fFace[I,i],fFace[I-δ(i,I),j],fFace[I,j]
     s = (f1+f2+f3+f4)/4
-    fmin = λρ < 1 ? min(f1+f2,f2+f3,f3+f4,f4+f1)/2 : max(f1+f2,f2+f3,f3+f4,f4+f1)/2
-    return μ*min(linInterpProp(s,λμ), ifelse(s>0.5,1,λμ/λρ)*linInterpProp(fmin,λρ))
+    f_ρmin = λρ < 1 ? min(f1,f2,f3,f4) : max(f1,f2,f3,f4)
+    return μ*min(linInterpProp(s,λμ), ifelse(s>0.5,1,λμ/λρ)*linInterpProp(f_ρmin,λρ))
 end
 
 """

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -110,12 +110,14 @@ end
 # This is the place for ρu forcing that does not need directional split
 function viscSurfTenρu!(r,u,ρuf,Φ,f,α,n̂,fbuffer,λμ,μ,λρ,η;perdir=())
     fill!(r,0)
-    visc!(r,u,ρuf,Φ,f,λμ,μ,λρ;perdir)
+    visc!(r,u,ρuf,n̂,Φ,f,λμ,μ,λρ;perdir)
     surfTen!(r,f,α,n̂,fbuffer,η;perdir)
 end
 
-function visc!(r,u,ρuf,Φ,f,λμ,μ::Number,λρ;perdir=())
+function visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
     N,D = size_u(u)
+
+    f2ρface!(fFace,f,λρ;perdir)
 
     # i is velocity direction (uᵢ)
     # j is face direction (differential) (∂ⱼ)
@@ -124,29 +126,29 @@ function visc!(r,u,ρuf,Φ,f,λμ,μ::Number,λρ;perdir=())
     for i∈1:D, j∈1:D
         tagper = (j∈perdir)
         # treatment for bottom boundary with BCs
-        lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,Val{tagper}())
+        lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,Val{tagper}())
         # inner cells
-        @loop (Φ[I] = - viscF(i,j,I,u,f,λμ,μ,λρ);
+        @loop (Φ[I] = - viscF(i,j,I,u,f,fFace,λμ,μ,λρ);
                 r[I,i] += Φ[I]) over I ∈ inside_u(N,j)
         @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
         # treatment for upper boundary with BCs
-        upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,Val{tagper}())
+        upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,Val{tagper}())
     end
 end
 visc!(r,u,ρuf,Φ,f,λμ,μ::Nothing,λρ;perdir=()) = nothing
 
 
 # Viscous forcing overload
-@inline viscF(i,j,I,u,f,λμ,μ,λρ) = (i==j ? getμCell(i,j,I,f,λμ,μ,λρ) : getμEdge(i,j,I,f,λμ,μ,λρ)) *(∂(j,CI(I,i),u)+∂(i,CI(I,j),u))
+@inline viscF(i,j,I,u,f,fFace,λμ,μ,λρ) = (i==j ? getμCell(i,j,I,f,fFace,λμ,μ,λρ) : getμEdge(i,j,I,f,fFace,λμ,μ,λρ)) *(∂(j,CI(I,i),u)+∂(i,CI(I,j),u))
 
 # Neumann BC Building block
-lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,::Val{false}) = @loop r[I,i] += - viscF(i,j,I,u,f,λμ,μ,λρ) over I ∈ slice(N,2,j,2)
-upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,::Val{false}) = @loop r[I-δ(j,I),i] += viscF(i,j,I,u,f,λμ,μ,λρ) over I ∈ slice(N,N[j],j,2)
+lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I,i] += - viscF(i,j,I,u,f,fFace,λμ,μ,λρ) over I ∈ slice(N,2,j,2)
+upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I-δ(j,I),i] += viscF(i,j,I,u,f,fFace,λμ,μ,λρ) over I ∈ slice(N,N[j],j,2)
 
 # Periodic BC Building block
-lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,::Val{true}) = @loop (
-    Φ[I] = -viscF(i,j,I,u,f,λμ,μ,λρ); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
-upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,λμ,μ,λρ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
+lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{true}) = @loop (
+    Φ[I] = -viscF(i,j,I,u,f,fFace,λμ,μ,λρ); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
+upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -75,7 +75,7 @@ end
     # TODO: include measure
     fill!(a.μ₀,1)
     @. c.f⁰ = (c.f⁰+c.f)/2
-    viscSurfTenρu!(a.f,a.u,c.ρuf,a.σ,c.f⁰,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir)
+    viscSurfTenρu!(a.f,a.u,a.σ,c.f⁰,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir)
     u2ρu!(c.n̂,a.u⁰,c.f,c.λρ) # steal n̂ as original momentum
     updateU!(a.u,c.ρu,c.n̂,a.f,δt,c.f⁰,c.λρ,tₘ,a.g,a.uBC,dtCoeff); BC!(a.u,a.uBC,a.exitBC,a.perdir)
     updateL!(a.μ₀,c.f⁰,c.λρ;perdir=a.perdir); 
@@ -96,7 +96,7 @@ end
     fill!(a.μ₀,1)
     # TODO: viscous term and surface tension term should be evaluated 
     # at the end of time step to avoid divide by wrong ρ
-    viscSurfTenρu!(a.f,a.u,c.ρuf,a.σ,c.f,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir) 
+    viscSurfTenρu!(a.f,a.u,a.σ,c.f,c.α,c.n̂,c.fᶠ,c.λμ,c.μ,c.λρ,c.η;perdir=a.perdir) 
     u2ρu!(c.n̂,a.u⁰,c.f,c.λρ) # steal n̂ as original momentum
     updateU!(a.u,c.ρu,c.n̂,a.f,δt,c.f,c.λρ,t₁,a.g,a.uBC); BC!(a.u,a.uBC,a.exitBC,a.perdir)
     updateL!(a.μ₀,c.f,c.λρ;perdir=a.perdir); 
@@ -108,13 +108,13 @@ end
 
 # Forcing with the unit of ρu instead of u
 # This is the place for ρu forcing that does not need directional split
-function viscSurfTenρu!(r,u,ρuf,Φ,f,α,n̂,fbuffer,λμ,μ,λρ,η;perdir=())
+function viscSurfTenρu!(r,u,Φ,f,α,n̂,fbuffer,λμ,μ,λρ,η;perdir=())
     fill!(r,0)
-    visc!(r,u,ρuf,n̂,Φ,f,λμ,μ,λρ;perdir)
+    visc!(r,u,n̂,Φ,f,λμ,μ,λρ;perdir)
     surfTen!(r,f,α,n̂,fbuffer,η;perdir)
 end
 
-function visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
+function visc!(r,u,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
     N,D = size_u(u)
 
     f2face!(fFace,f;perdir)
@@ -126,29 +126,29 @@ function visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
     for i∈1:D, j∈1:D
         tagper = (j∈perdir)
         # treatment for bottom boundary with BCs
-        lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,Val{tagper}())
+        lowerBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,Val{tagper}())
         # inner cells
-        @loop (Φ[I] = - viscF(i,j,I,u,f,fFace,λμ,μ,λρ);
+        @loop (Φ[I] = - viscF(i,j,I,u,fFace,λμ,μ,λρ);
                 r[I,i] += Φ[I]) over I ∈ inside_u(N,j)
         @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
         # treatment for upper boundary with BCs
-        upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,Val{tagper}())
+        upperBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,Val{tagper}())
     end
 end
-visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Nothing,λρ;perdir=()) = nothing
+visc!(r,u,fFace,Φ,f,λμ,μ::Nothing,λρ;perdir=()) = nothing
 
 
 # Viscous forcing overload
-@inline viscF(i,j,I,u,f,fFace,λμ,μ,λρ) = (i==j ? getμCell(i,j,I,f,fFace,λμ,μ,λρ) : getμEdge(i,j,I,f,fFace,λμ,μ,λρ)) *(∂(j,CI(I,i),u)+∂(i,CI(I,j),u))
+@inline viscF(i,j,I,u,fFace,λμ,μ,λρ) = getμ(i,j,I,fFace,λμ,μ,λρ) * (∂(j,CI(I,i),u)+∂(i,CI(I,j),u))
 
 # Neumann BC Building block
-lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I,i] += - viscF(i,j,I,u,f,fFace,λμ,μ,λρ) over I ∈ slice(N,2,j,2)
-upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I-δ(j,I),i] += viscF(i,j,I,u,f,fFace,λμ,μ,λρ) over I ∈ slice(N,N[j],j,2)
+lowerBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I,i] += - viscF(i,j,I,u,fFace,λμ,μ,λρ) over I ∈ slice(N,2,j,2)
+upperBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,::Val{false}) = @loop r[I-δ(j,I),i] += viscF(i,j,I,u,fFace,λμ,μ,λρ) over I ∈ slice(N,N[j],j,2)
 
 # Periodic BC Building block
-lowerBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{true}) = @loop (
-    Φ[I] = -viscF(i,j,I,u,f,fFace,λμ,μ,λρ); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
-upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
+lowerBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,::Val{true}) = @loop (
+    Φ[I] = -viscF(i,j,I,u,fFace,λμ,μ,λρ); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
+upperBoundaryVisc!(r,u,Φ,i,j,N,fFace,λμ,μ,λρ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -117,7 +117,7 @@ end
 function visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
     N,D = size_u(u)
 
-    f2ρface!(fFace,f,λρ;perdir)
+    f2face!(fFace,f;perdir)
 
     # i is velocity direction (uᵢ)
     # j is face direction (differential) (∂ⱼ)
@@ -135,7 +135,7 @@ function visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Number,λρ;perdir=())
         upperBoundaryVisc!(r,u,ρuf,Φ,i,j,N,f,fFace,λμ,μ,λρ,Val{tagper}())
     end
 end
-visc!(r,u,ρuf,Φ,f,λμ,μ::Nothing,λρ;perdir=()) = nothing
+visc!(r,u,ρuf,fFace,Φ,f,λμ,μ::Nothing,λρ;perdir=()) = nothing
 
 
 # Viscous forcing overload


### PR DESCRIPTION
Inline viscosity estimation require `f[I-δ(i,I)-δ(i,I)]` which make the boundary terms very hard to be estimated. To solve this, I calculate f at face first and thus the issue can be circumvented. Furthermore, the Inline/Cross viscosity calculation can be elegantly unified